### PR TITLE
Read bot token from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ pip install -r requirements.txt
 ### Настройка
 
 1. Создайте нового бота через [@BotFather](https://t.me/BotFather)
-2. Получите токен и добавьте его в `config.py`:
+2. Получите токен и сохраните его в переменной окружения `BOT_TOKEN`:
 
-```python
-TOKEN = "your_bot_token_here"
+```bash
+export BOT_TOKEN="your_bot_token_here"
 ```
 
 3. Создайте структуру каталогов:
@@ -52,6 +52,8 @@ mkdir -p data/icals db
 ```
 
 ### Запуск
+
+Убедитесь, что переменная окружения `BOT_TOKEN` установлена.
 
 ```bash
 cd code

--- a/code/config.py
+++ b/code/config.py
@@ -1,1 +1,5 @@
-TOKEN = "**********:***************************"
+import os
+
+TOKEN = os.getenv("BOT_TOKEN")
+if not TOKEN:
+    raise ValueError("BOT_TOKEN environment variable not set")


### PR DESCRIPTION
## Summary
- load Telegram bot token from `BOT_TOKEN` environment variable
- document environment variable requirement in README

## Testing
- `python -m py_compile code/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6894ba7215348330a534b83ca22b729c