### PR TITLE
Allow yandex-team.ru export links

### DIFF
--- a/code/bot.py
+++ b/code/bot.py
@@ -25,7 +25,7 @@ def is_valid_ical_url(url: str) -> bool:
         return False
     if parsed.scheme not in ('http', 'https'):
         return False
-    if not parsed.netloc.endswith('yandex.ru'):
+    if not parsed.netloc.endswith(('yandex.ru', 'yandex-team.ru')):
         return False
     if parsed.path.endswith('.ics'):
         return True


### PR DESCRIPTION
## Summary
- allow calendar export links from yandex-team.ru

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689626f9ff048330932438ab1c4ae2a3